### PR TITLE
issue #22 - get rid of 'final' in UUIDTimer consistently to internal JavaDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,9 @@ target
 .project
 .settings
 
+# plus IDEA crap
+*.iml
+*.ipr
+.idea
+
 *~

--- a/src/main/java/com/fasterxml/uuid/UUIDTimer.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDTimer.java
@@ -30,11 +30,11 @@ import com.fasterxml.uuid.impl.UUIDUtil;
  *   To compensate, an additional counter is used,
  *   so that more than one UUID can be generated between java clock
  *   updates. Counter may be used to generate up to 10000 UUIDs for
- *   each distrinct java clock value.
+ *   each distinct java clock value.
  *<li>Due to even lower clock resolution on some platforms (older
  *  Windows versions use 55 msec resolution), timestamp value can
  *  also advanced ahead of physical value within limits (by default,
- *  up 100 millisecond ahead of reported), iff necessary (ie. 10000
+ *  up 100 millisecond ahead of reported), if necessary (ie. 10000
  *  instances created before clock time advances).
  *<li>As an additional precaution, counter is initialized not to 0
  *   but to a random 8-bit number, and each time clock changes, lowest
@@ -70,7 +70,7 @@ import com.fasterxml.uuid.impl.UUIDUtil;
  * 3.1.1 and above) is {@link #getTimestamp}, so caller need not
  * synchronize access explicitly.
  */
-public final class UUIDTimer
+public class UUIDTimer
 {
     // // // Constants
 
@@ -211,7 +211,7 @@ public final class UUIDTimer
      *
      * @return 64-bit timestamp to use for constructing UUID
      */
-    public final synchronized long getTimestamp()
+    public synchronized long getTimestamp()
     {
         long systime = System.currentTimeMillis();
         /* Let's first verify that the system time is not going backwards;
@@ -298,7 +298,7 @@ public final class UUIDTimer
      */
     
     /* Method for accessing timestamp to use for creating UUIDs.
-     * Used ONLY by unit tests, hence protexted.
+     * Used ONLY by unit tests, hence protected.
      */
     protected final void getAndSetTimestamp(byte[] uuidBytes)
     {
@@ -342,7 +342,7 @@ public final class UUIDTimer
      * @param msecs Number of milliseconds to wait for from current 
      *    time point
      */
-    private final static void slowDown(long startTime, long actDiff)
+    private static void slowDown(long startTime, long actDiff)
     {
         /* First, let's determine how long we'd like to wait.
          * This is based on how far ahead are we as of now.


### PR DESCRIPTION
I've removed 'final' keyword to allow implementing subclasses of UUIDTimer.

The reason why we need this is an attempt to eliminate 'synchronized' on getTimestamp() and try to implement non-blocking (CAS) algorithm