### PR TITLE
maven-compiler-plugin 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@ JUG supports all 3 official UUID generation methods.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.8.0</version>
           <configuration>
             <source>1.6</source>
             <target>1.6</target>


### PR DESCRIPTION
notes about version 3.8.0:

https://blogs.apache.org/maven/entry/apache-maven-compiler-plugin-version

![image](https://user-images.githubusercontent.com/30938/51512134-41b44800-1db9-11e9-994f-7ce01637dec3.png)
