### PR TITLE
Add customisable clock to UUIDTimer

### DIFF
--- a/src/main/java/com/fasterxml/uuid/UUIDClock.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDClock.java
@@ -1,0 +1,34 @@
+/* JUG Java Uuid Generator
+ *
+ * Copyright (c) 2002 Tatu Saloranta, tatu.saloranta@iki.fi
+ *
+ * Licensed under the License specified in the file LICENSE which is
+ * included with the source code.
+ * You may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fasterxml.uuid;
+
+/**
+ * UUIDClock is used by UUIDTimer to get the current time. The default
+ * implementation returns the time from the system clock, but this class can
+ * be overriden to return any number. This is useful when UUIDs with past or
+ * future timestamps should be generated, or when UUIDs must be generated in
+ * a reproducible manner.
+ */
+public class UUIDClock
+{
+    /**
+     * Returns the current time in milliseconds.
+     */
+    public long currentTimeMillis()
+    {
+        return System.currentTimeMillis();
+    }
+}

--- a/src/main/java/com/fasterxml/uuid/UUIDTimer.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDTimer.java
@@ -113,6 +113,11 @@ public class UUIDTimer
      */
     protected final Random _random;
 
+    /**
+     * Clock used to get the time when a timestamp is requested.
+     */
+    protected final UUIDClock _clock;
+
     // // // Clock state:
 
     /**
@@ -159,8 +164,14 @@ public class UUIDTimer
 
     public UUIDTimer(Random rnd, TimestampSynchronizer sync) throws IOException
     {
+        this(rnd, sync, new UUIDClock());
+    }
+
+    public UUIDTimer(Random rnd, TimestampSynchronizer sync, UUIDClock clock) throws IOException
+    {
         _random = rnd;
         _syncer = sync;
+        _clock = clock;
         initCounters(rnd);
         _lastSystemTimestamp = 0L;
         // This may get overwritten by the synchronizer
@@ -213,7 +224,7 @@ public class UUIDTimer
      */
     public synchronized long getTimestamp()
     {
-        long systime = System.currentTimeMillis();
+        long systime = _clock.currentTimeMillis();
         /* Let's first verify that the system time is not going backwards;
          * independent of whether we can use it:
          */

--- a/src/test/java/com/fasterxml/uuid/UUIDTimerTest.java
+++ b/src/test/java/com/fasterxml/uuid/UUIDTimerTest.java
@@ -22,6 +22,7 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Random;
 import java.util.Set;
 
 import junit.framework.Test;
@@ -186,6 +187,31 @@ public class UUIDTimerTest extends TestCase
         // check that all timestamps are between the start and end time
         checkUUIDTimerLongArrayForCorrectCreationTime(
             uuid_timer_array_of_longs, start_time, end_time);
+    }
+
+    /**
+     * Test of reproducibility of getTimestamp method, of class
+     * com.fasterxml.uuid.UUIDTimer.
+     */
+    public void testGetTimestampReproducible() throws IOException
+    {
+        final long seed = new Random().nextLong();
+        final long time = new Random().nextLong();
+
+        final UUIDTimer timer1 = new UUIDTimer(new Random(seed), null, new UUIDClock() {
+            @Override
+            public long currentTimeMillis() {
+                return time;
+            }
+        });
+        final UUIDTimer timer2 = new UUIDTimer(new Random(seed), null, new UUIDClock() {
+            @Override
+            public long currentTimeMillis() {
+                return time;
+            }
+        });
+
+        assertEquals(timer1.getTimestamp(), timer2.getTimestamp());
     }
     
     /**************************************************************************


### PR DESCRIPTION
Fixes #20.

Adds a class called `UUIDClock` of which the only purpose is to return the current time using `System.currentTimeMillis()`. End users can create a subclass of `UUIDClock` to return whatever they want. The `UUIDClock` is given to the `UUIDTimer` in its constructor, and the clock is used instead of directly calling `System.currentTimeMillis`. I've added a separate constructor to `UUIDTimer` for backwards compatibility; using the old constructor will cause the `UUIDTimer` to use the default implementation of `UUIDClock`.

I've added a single test which verifies that creating two _different_ `UUIDTimer`s in _the same way_ will result in the same result.