### PR TITLE
TimeBasedGenerator factory method that defaults to a sensible choice of interface

### DIFF
--- a/src/main/java/com/fasterxml/uuid/Generators.java
+++ b/src/main/java/com/fasterxml/uuid/Generators.java
@@ -39,6 +39,11 @@ public class Generators
      * synchronization but no external file-based syncing.
      */
     protected static UUIDTimer _sharedTimer;
+
+    /**
+     * The default egress network interface.
+     */
+    protected static EthernetAddress _egressIfAddr = null;
     
     // // Random-based generation
     
@@ -114,6 +119,18 @@ public class Generators
     }
     
     // // Time+location-based generation
+
+    /**
+     * Factory method for constructing UUID generator that generates UUID using variant 1
+     * (time+location based). This method will use the ethernet address of the interface
+     * that routes to the default gateway. For most simple and common networking configurations
+     * this will be the most appropriate address to use. The default interface is determined
+     * by the calling {@link EthernetAddress#fromEgressInterface()}.
+     */
+    public static TimeBasedGenerator egressTimeBasedGenerator()
+    {
+        return timeBasedGenerator(egressInterfaceAddress());
+    }
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
@@ -195,4 +212,12 @@ public class Generators
         }
         return _sharedTimer;
     }
+
+    private static synchronized EthernetAddress egressInterfaceAddress() 
+    {
+    	  if (_egressIfAddr == null) {
+    	      _egressIfAddr = EthernetAddress.fromEgressInterface();
+    	  }
+    	  return _egressIfAddr;
+  	}
 }

--- a/src/test/java/com/fasterxml/uuid/EthernetAddressTest.java
+++ b/src/test/java/com/fasterxml/uuid/EthernetAddressTest.java
@@ -17,6 +17,8 @@
 
 package com.fasterxml.uuid;
 
+import com.fasterxml.uuid.impl.TimeBasedGenerator;
+import java.net.InetSocketAddress;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
@@ -24,8 +26,6 @@ import junit.textui.TestRunner;
 
 import java.util.Arrays;
 import java.util.Random;
-
-import com.fasterxml.uuid.EthernetAddress;
 
 /**
  * JUnit Test class for the com.fasterxml.uuid.EthernetAddress class.
@@ -1307,6 +1307,45 @@ public class EthernetAddressTest extends TestCase
         EthernetAddress addr = EthernetAddress.fromInterface();
         assertNotNull(addr);
         assertNotNull(addr.toString());
+    }
+
+    public void testFromEgressInterfaceRoot() throws Exception
+    {
+        InetSocketAddress extAddr = new InetSocketAddress("a.root-servers.net", 0);
+        EthernetAddress ifAddr = EthernetAddress.fromEgressInterface(extAddr);
+        assertNotNull(ifAddr);
+        assertNotNull(ifAddr.toString());
+    }
+
+    public void testFromEgressInterfaceIp4() throws Exception
+    {
+        InetSocketAddress extAddr = new InetSocketAddress("1.1.1.1", 0);
+        EthernetAddress ifAddr = EthernetAddress.fromEgressInterface(extAddr);
+        assertNotNull(ifAddr);
+        assertNotNull(ifAddr.toString());
+    }
+
+    public void testFromEgressInterfaceIp6() throws Exception
+    {
+        InetSocketAddress extAddr = new InetSocketAddress("1::1", 0);
+        EthernetAddress ifAddr = EthernetAddress.fromEgressInterface(extAddr);
+        assertNotNull(ifAddr);
+        assertNotNull(ifAddr.toString());
+    }
+
+    public void testFromEgressInterface() throws Exception
+    {
+        EthernetAddress ifAddr = EthernetAddress.fromEgressInterface();
+        assertNotNull(ifAddr);
+        assertNotNull(ifAddr.toString());
+    }
+
+    public void testDefaultTimeBasedGenerator()
+    {
+        TimeBasedGenerator generator = Generators.egressTimeBasedGenerator();
+        EthernetAddress ifAddr = generator.getEthernetAddress();
+        assertNotNull(ifAddr);
+        assertNotNull(ifAddr.toString());
     }
 
     public void testBogus() throws Exception


### PR DESCRIPTION
egressTimeBasedGenerator() factory method that will make an educated guess as to which interface to use, by trying to find the interface corresponding to the local default network route