### PR TITLE
Rename variants to versions in documentation and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ The original use case for JUG was generation of UUID values. This is done by fir
 For example:
 
 ```java
-UUID uuid = Generators.timeBasedGenerator().generate(); // Variant 1
-UUID uuid = Generators.randomBasedGenerator().generate(); // Variant 4
-UUID uuid = Generators.nameBasedgenerator().generate("string to hash"); // Variant 5
-// With JUG 4.1+: support for https://github.com/uuid6/uuid6-ietf-draft variants 6 and 7:
-UUID uuid = Generators.timeBasedReorderedGenerator().generate(); // Variant 6
-UUID uuid = Generators.timeBasedEpochGenerator().generate(); // Variant 7
+UUID uuid = Generators.timeBasedGenerator().generate(); // Version 1
+UUID uuid = Generators.randomBasedGenerator().generate(); // Version 4
+UUID uuid = Generators.nameBasedgenerator().generate("string to hash"); // Version 5
+// With JUG 4.1+: support for https://github.com/uuid6/uuid6-ietf-draft versions 6 and 7:
+UUID uuid = Generators.timeBasedReorderedGenerator().generate(); // Version 6
+UUID uuid = Generators.timeBasedEpochGenerator().generate(); // Version 7
 ```
 
 If you want customize generators, you may also just want to hold on to generator instance:
@@ -137,7 +137,7 @@ and get full instructions, but to generate 5 Random-based UUIDs, you would use:
 
     java -jar target/java-uuid-generator-4.1.1-SNAPSHOT.jar -c 5 r
 
-(where `-c` (or `--count`) means number of UUIDs to generate, and `r` means Random-based variant)
+(where `-c` (or `--count`) means number of UUIDs to generate, and `r` means Random-based version)
 
 NOTE: this functionality is included as of JUG 4.1 -- with earlier versions you would need a bit longer invocation as Jar metadata did not specify "Main-Class".
 If so, you would need to use

--- a/release-notes/FAQ
+++ b/release-notes/FAQ
@@ -55,7 +55,7 @@ Name-based:	1 million/second (depends on length, namespace etc; this with MD5)
 
 So with default settings, time-based algorithm is by far the fastest;
 usually followed by name/hash based alternative (for short/medium
-names at least), and random-based variant being slowest.
+names at least), and random-based version being slowest.
 
 Finally, if performance _really_ is very important for you, there
 is a further complication when using time-based algorithm; Java's
@@ -95,7 +95,7 @@ native uuidgen), using random-based method may be the best option;
 although there is a file-locking base synchronizer available for
 time-based generation. This works with multiple JVMs, but may not
 be applicable to synchronize with non-Java generators.
-Random-number based variant should be safe to use, as long as the
+Random-number based version should be safe to use, as long as the
 underlying random number generator is good (which SecureRandom by
 JDK should be).
 

--- a/release-notes/USAGE
+++ b/release-notes/USAGE
@@ -49,7 +49,7 @@ the way a new JVM is usually instantiated between calls:
 
 * Generating the first UUID can be remarkably slow. This is because
   a new secure random number generator is initialized at that time (if
-  using random number based variant)
+  using random number based version)
   Subsequent calls are faster, but this has to be done using --count
   command-line argument, to create multiple UUIDs with same invocation.
 * Generating time-based UUIDs is not as secure due to JVM being re-initialized

--- a/src/main/java/com/fasterxml/uuid/Generators.java
+++ b/src/main/java/com/fasterxml/uuid/Generators.java
@@ -119,7 +119,7 @@ public class Generators
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 7 (Unix Epoch time+random based).
+     * version 7 (Unix Epoch time+random based).
     */
     public static TimeBasedEpochGenerator timeBasedEpochGenerator()
     {
@@ -128,7 +128,7 @@ public class Generators
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 7 (time+random based), using specified Ethernet address
+     * version 7 (time+random based), using specified Ethernet address
      * as the location part of UUID.
      * No additional external synchronization is used.
      */
@@ -141,7 +141,7 @@ public class Generators
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 1 (time+location based).
+     * version 1 (time+location based).
      * Since no Ethernet address is passed, a bogus broadcast address will be
      * constructed for purpose of UUID generation; usually it is better to
      * instead access one of host's NIC addresses using
@@ -155,7 +155,7 @@ public class Generators
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 1 (time+location based), using specified Ethernet address
+     * version 1 (time+location based), using specified Ethernet address
      * as the location part of UUID.
      * No additional external synchronization is used.
      */
@@ -166,7 +166,7 @@ public class Generators
     
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 1 (time+location based), using specified Ethernet address
+     * version 1 (time+location based), using specified Ethernet address
      * as the location part of UUID, and specified synchronizer (which may add
      * additional restrictions to guarantee system-wide uniqueness).
      * 
@@ -189,7 +189,7 @@ public class Generators
     
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 1 (time+location based), using specified Ethernet address
+     * version 1 (time+location based), using specified Ethernet address
      * as the location part of UUID, and specified {@link UUIDTimer} instance
      * (which includes embedded synchronizer that defines synchronization behavior).
      */
@@ -206,7 +206,7 @@ public class Generators
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 6 (time+location based, reordered for DB locality). Since no Ethernet
+     * version 6 (time+location based, reordered for DB locality). Since no Ethernet
      * address is passed, a bogus broadcast address will be constructed for purpose
      * of UUID generation; usually it is better to instead access one of host's NIC
      * addresses using {@link EthernetAddress#fromInterface} which will use one of
@@ -219,7 +219,7 @@ public class Generators
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 6 (time+location based, reordered for DB locality), using specified
+     * version 6 (time+location based, reordered for DB locality), using specified
      * Ethernet address as the location part of UUID. No additional external
      * synchronization is used.
      */
@@ -230,7 +230,7 @@ public class Generators
 
     /**
      * Factory method for constructing UUID generator that generates UUID using
-     * variant 6 (time+location based, reordered for DB locality), using specified
+     * version 6 (time+location based, reordered for DB locality), using specified
      * Ethernet address as the location part of UUID, and specified
      * {@link UUIDTimer} instance (which includes embedded synchronizer that defines
      * synchronization behavior).

--- a/src/main/java/com/fasterxml/uuid/Jug.java
+++ b/src/main/java/com/fasterxml/uuid/Jug.java
@@ -31,8 +31,8 @@ public class Jug
         TYPES.put("time-based", "t");
         TYPES.put("random-based", "r");
         TYPES.put("name-based", "n");
-        TYPES.put("reordered-time-based", "o"); // Variant 6
-        TYPES.put("epoch-time-based", "e"); // Variant 7
+        TYPES.put("reordered-time-based", "o"); // Version 6
+        TYPES.put("epoch-time-based", "e"); // Version 7
     }
 
     protected final static HashMap<String,String> OPTIONS = new HashMap<String,String>();
@@ -227,7 +227,7 @@ public class Jug
 
         switch (typeC) {
         case 't': // time-based
-        case 'o': // reordered-time-based (Variant 6)
+        case 'o': // reordered-time-based (Version 6)
             // 30-Jun-2022, tatu: Is this true? My former self must have had his
             //    reasons so leaving as is but... odd.
             usesRnd = true;

--- a/src/main/java/com/fasterxml/uuid/NoArgGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/NoArgGenerator.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 /**
  * Intermediate base class for UUID generators that do not take arguments for individual
- * calls. This includes random and time-based variants, but not name-based ones.
+ * calls. This includes random and time-based versions, but not name-based ones.
  * 
  * @since 3.0
  */

--- a/src/main/java/com/fasterxml/uuid/UUIDComparator.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDComparator.java
@@ -6,13 +6,13 @@ import java.util.UUID;
 /**
  * Default {@link java.util.UUID} comparator is not very useful, since
  * it just does blind byte-by-byte comparison which does not work well
- * for time+location - based UUIDs. Additionally it also uses signed
+ * for time+location - based UUIDs. Additionally, it also uses signed
  * comparisons for longs which can lead to unexpected behavior
  * This comparator does implement proper lexical ordering: starting with
  * type (different types are collated
  * separately), followed by time and location (for time/location based),
  * and simple lexical (byte-by-byte) ordering for name/hash and random
- * variants.
+ * versions.
  * 
  * @author tatu
  */
@@ -36,7 +36,7 @@ public class UUIDComparator implements Comparator<UUID>
         if (diff != 0) {
             return diff;
         }
-        // Second: for time-based variant, order by time stamp:
+        // Second: for time-based version, order by time stamp:
         if (type == UUIDType.TIME_BASED.raw()) {
             diff = compareULongs(u1.timestamp(), u2.timestamp());
             if (diff == 0) {

--- a/src/main/java/com/fasterxml/uuid/UUIDGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDGenerator.java
@@ -42,7 +42,7 @@ public abstract class UUIDGenerator
      */
 
     /**
-     * Accessor for determining type of UUIDs (variant) that this
+     * Accessor for determining type of UUIDs (version) that this
      * generator instance will produce.
      */
     public abstract UUIDType getType();

--- a/src/main/java/com/fasterxml/uuid/impl/NameBasedGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/NameBasedGenerator.java
@@ -9,7 +9,7 @@ import com.fasterxml.uuid.UUIDType;
 
 /**
  * Implementation of UUID generator that uses one of name-based generation methods
- * (variants 3 (MD5) and 5 (SHA1)).
+ * (versions 3 (MD5) and 5 (SHA1)).
  *<p>
  * As all JUG provided implementations, this generator is fully thread-safe; access
  * to digester is synchronized as necessary.

--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedEpochGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedEpochGenerator.java
@@ -11,7 +11,7 @@ import com.fasterxml.uuid.UUIDType;
  * Implementation of UUID generator that uses time/location based generation
  * method field from the Unix Epoch timestamp source - the number of 
  * milliseconds seconds since midnight 1 Jan 1970 UTC, leap seconds excluded.
- * This is usually referred to as "Variant 7".
+ * This is usually referred to as "Version 7".
  * <p>
  * As all JUG provided implementations, this generator is fully thread-safe.
  * Additionally it can also be made externally synchronized with other instances

--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedGenerator.java
@@ -6,10 +6,10 @@ import com.fasterxml.uuid.*;
 
 /**
  * Implementation of UUID generator that uses time/location based generation
- * method (variant 1).
+ * method (version 1).
  *<p>
  * As all JUG provided implementations, this generator is fully thread-safe.
- * Additionally it can also be made externally synchronized with other
+ * Additionally, it can also be made externally synchronized with other
  * instances (even ones running on other JVMs); to do this,
  * use {@link com.fasterxml.uuid.ext.FileBasedTimestampSynchronizer}
  * (or equivalent).

--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedReorderedGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedReorderedGenerator.java
@@ -7,7 +7,7 @@ import com.fasterxml.uuid.*;
 /**
  * Implementation of UUID generator that uses time/location based generation
  * method field compatible with UUIDv1, reorderd for improved DB locality.
- * This is usually referred to as "Variant 6".
+ * This is usually referred to as "Version 6".
  * <p>
  * As all JUG provided implementations, this generator is fully thread-safe.
  * Additionally it can also be made externally synchronized with other instances

--- a/src/main/java/perf/MeasurePerformance.java
+++ b/src/main/java/perf/MeasurePerformance.java
@@ -8,12 +8,12 @@ import com.fasterxml.uuid.impl.TimeBasedGenerator;
 
 /**
  * Simple micro-benchmark for evaluating performance of various UUID generation
- * techniques, including JDK's method as well as JUG's variants.
+ * techniques, including JDK's method as well as JUG's versions.
  *<p>
- * Notes: for name-based variant we will pass plain Strings, assuming this is the
+ * Notes: for name-based version we will pass plain Strings, assuming this is the
  * most common use case; even though it is possible to also pass raw byte arrays.
  * JDK and Jug implementations have similar performance so this only changes
- * relative speeds of name- vs time-based variants.
+ * relative speeds of name- vs time-based versions.
  *
  * @since 3.1
  */

--- a/src/test/java/com/fasterxml/uuid/UUIDGeneratorTest.java
+++ b/src/test/java/com/fasterxml/uuid/UUIDGeneratorTest.java
@@ -703,7 +703,7 @@ public class UUIDGeneratorTest extends TestCase
         }
     }
 
-    // Modified version for Variant 6 (reordered timestamps)
+    // Modified version for Version 6 (reordered timestamps)
     private void checkUUIDArrayForCorrectCreationTimeReorder(UUID[] uuidArray,
             long startTime, long endTime)
     {
@@ -757,7 +757,7 @@ public class UUIDGeneratorTest extends TestCase
         }
     }
 
-    // Modified version for Variant 7 (Unix Epoch timestamps)
+    // Modified version for Version 7 (Unix Epoch timestamps)
     private void checkUUIDArrayForCorrectCreationTimeEpoch(UUID[] uuidArray,
             long startTime, long endTime)
     {


### PR DESCRIPTION
Hello,

This PR addresses issue #67, which highlighted an inconsistency in the codebase regarding the use of "variant" and "version" to refer to UUIDs. After reviewing the code and documentation, I have made changes to replace all instances of "variant" with "version" to reflect the correct terminology.

Thank you.