### PR TITLE
Add `construct()` methods to specify the milliseconds being used for time-based UUID generation

### DIFF
--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedEpochGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedEpochGenerator.java
@@ -97,13 +97,16 @@ public class TimeBasedEpochGenerator extends NoArgGenerator
     /* UUID generation
     /**********************************************************************
      */
-    
+
     @Override
-    public UUID generate()
+    public UUID generate() {
+        return generate(_clock.currentTimeMillis());
+    }
+    
+    public UUID generate(long rawTimestamp)
     {
         lock.lock();
         try { 
-            long rawTimestamp = _clock.currentTimeMillis();
             if (rawTimestamp == _lastTimestamp) {
                 boolean c = true;
                 for (int i = ENTROPY_BYTE_LENGTH - 1; i >= 0; i--) {

--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedEpochGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedEpochGenerator.java
@@ -99,11 +99,17 @@ public class TimeBasedEpochGenerator extends NoArgGenerator
      */
 
     @Override
-    public UUID generate() {
-        return generate(_clock.currentTimeMillis());
+    public UUID generate()
+    {
+        return construct(_clock.currentTimeMillis());
     }
-    
-    public UUID generate(long rawTimestamp)
+
+    /**
+     * @since 4.3
+     * @param rawTimestamp unix epoch millis
+     * @return unix epoch time based UUID
+     */
+    public UUID construct(long rawTimestamp)
     {
         lock.lock();
         try { 

--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedGenerator.java
@@ -87,9 +87,13 @@ public class TimeBasedGenerator extends NoArgGenerator
      */
 
     @Override
-    public UUID generate()
-    {
+    public UUID generate() {
         final long rawTimestamp = _timer.getTimestamp();
+        return generate(rawTimestamp);
+    }
+
+    public UUID generate(long rawTimestamp)
+    {
         // Time field components are kind of shuffled, need to slice:
         int clockHi = (int) (rawTimestamp >>> 32);
         int clockLo = (int) rawTimestamp;

--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedGenerator.java
@@ -87,12 +87,18 @@ public class TimeBasedGenerator extends NoArgGenerator
      */
 
     @Override
-    public UUID generate() {
+    public UUID generate()
+    {
         final long rawTimestamp = _timer.getTimestamp();
-        return generate(rawTimestamp);
+        return construct(rawTimestamp);
     }
 
-    public UUID generate(long rawTimestamp)
+    /**
+     * @since 4.3
+     * @param rawTimestamp unix epoch millis
+     * @return unix epoch time based UUID
+     */
+    public UUID construct(long rawTimestamp)
     {
         // Time field components are kind of shuffled, need to slice:
         int clockHi = (int) (rawTimestamp >>> 32);

--- a/src/main/java/com/fasterxml/uuid/impl/TimeBasedReorderedGenerator.java
+++ b/src/main/java/com/fasterxml/uuid/impl/TimeBasedReorderedGenerator.java
@@ -96,7 +96,16 @@ public class TimeBasedReorderedGenerator extends NoArgGenerator
     {
         // Ok, get 60-bit timestamp (4 MSB are ignored)
         final long rawTimestamp = _timer.getTimestamp();
+        return construct(rawTimestamp);
+    }
 
+    /**
+     * @since 4.3
+     * @param rawTimestamp unix epoch millis
+     * @return unix epoch time based UUID
+     */
+    public UUID construct(long rawTimestamp)
+    {
         // First: discard 4 MSB, next 32 bits (top of 60-bit timestamp) form the
         // highest 32-bit segments
         final long timestampHigh = (rawTimestamp >>> 28) << 32;


### PR DESCRIPTION
This is useful for migrating existing sets of data which include a timestamp, but don't use ordered UUID values.