### PR TITLE
Fix LazyRandom for native code generation tools

### DIFF
--- a/src/main/java/com/fasterxml/uuid/impl/LazyRandom.java
+++ b/src/main/java/com/fasterxml/uuid/impl/LazyRandom.java
@@ -9,9 +9,26 @@ import java.security.SecureRandom;
  */
 public final class LazyRandom
 {
-    private final static SecureRandom shared = new SecureRandom();
+    private static final Object lock = new Object();
+    private static volatile SecureRandom shared;
 
     public static SecureRandom sharedSecureRandom() {
-        return shared;
+        // Double check lazy initialization idiom (Effective Java 3rd edition item 11.6)
+        // Use so that native code generation tools do not detect a SecureRandom instance in a static final field.
+        SecureRandom result = shared;
+
+        if (result != null) {
+            return result;
+        }
+
+        synchronized (lock) {
+            result = shared;
+
+            if (result == null) {
+                result = shared = new SecureRandom();
+            }
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Trying to generate a native code image with GraalVM in code that uses `TimeBasedEpochGenerator` results in this exception:

```
Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: Detected an instance of Random/SplittableRandom class in the image heap. Instances created during image generation have cached seed values and don't behave as expected.  To see how this object got instantiated use --trace-object-instantiation=java.security.SecureRandom. The object was probably created by a class initializer and is reachable from a static field. You can request class initialization at image runtime by using the option --initialize-at-run-time=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
        at parsing com.fasterxml.uuid.impl.LazyRandom.sharedSecureRandom(LazyRandom.java:12)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.throwParserError(BytecodeParser.java:2518)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.throwParserError(SharedGraphBuilderPhase.java:110)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3393)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3345)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3190)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1138)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1030)
        at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:97)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:84)
```

This happens because the `TimeBasedEpochGenerator` constructor initializes the `LazyRandom` class unconditionally, even if it is never actually used because the constructor is never passed a null `Random` instance, and `LazyRandom` eagerly creates a `SecureRandom` instance in a static final field.

Changing the `TimeBasedEpochGenerator` constructor would break backward compatibility, so instead I have opted to modify `LazyRandom` so that `SecureRandom` initialization actually occurs lazily. With this, the code path that results in initializing `LazyRandom.shared` is never hit at code generation phase, and so native image generation works as expected.