### PR TITLE
#105 UUIDUtil.extractTimestamp() is broken

### DIFF
--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -8,6 +8,8 @@ Releases
 
 #99: New factory method to create TimeBasedEpochRandomGenerator
  (contributed by Daniel A)
+#105: `UUIDUtil.extractTimestamp()` is broken for versions 1 and 6
+ (contributed by @magdel)
 
 5.0.0 (23-Feb-2024)
 

--- a/src/main/java/com/fasterxml/uuid/UUIDTimer.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDTimer.java
@@ -320,6 +320,16 @@ public class UUIDTimer
         return systime;
     }
 
+    /**
+     * Converts UUID v1 & v6 timestamp to Unix epoch timestamp
+     *
+     * @param timestamp timestamp, used to create UUID v1 & v6
+     * @return Unix epoch timestamp
+     */
+    public static long timestampToEpoch(long timestamp) {
+        return (timestamp - kClockOffset) / kClockMultiplierL;
+    }
+
     /*
     /**********************************************************************
     /* Test-support methods

--- a/src/main/java/com/fasterxml/uuid/UUIDTimer.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDTimer.java
@@ -321,10 +321,14 @@ public class UUIDTimer
     }
 
     /**
-     * Converts a UUID v1 or v6 timestamp to Unix epoch timestamp
+     * Converts a UUID v1 or v6 timestamp (where unit is 100 nanoseconds),
+     * to Unix epoch timestamp (milliseconds since 01-Jan-1970 UTC)
      *
-     * @param timestamp timestamp, used to create UUID versions 1 and 6
+     * @param timestamp Timestamp used to create UUID versions 1 and 6
+     *
      * @return Unix epoch timestamp
+     *
+     * @since 5.1
      */
     public static long timestampToEpoch(long timestamp) {
         return (timestamp - kClockOffset) / kClockMultiplierL;

--- a/src/main/java/com/fasterxml/uuid/UUIDTimer.java
+++ b/src/main/java/com/fasterxml/uuid/UUIDTimer.java
@@ -321,9 +321,9 @@ public class UUIDTimer
     }
 
     /**
-     * Converts UUID v1 & v6 timestamp to Unix epoch timestamp
+     * Converts a UUID v1 or v6 timestamp to Unix epoch timestamp
      *
-     * @param timestamp timestamp, used to create UUID v1 & v6
+     * @param timestamp timestamp, used to create UUID versions 1 and 6
      * @return Unix epoch timestamp
      */
     public static long timestampToEpoch(long timestamp) {

--- a/src/main/java/com/fasterxml/uuid/impl/UUIDUtil.java
+++ b/src/main/java/com/fasterxml/uuid/impl/UUIDUtil.java
@@ -2,6 +2,7 @@ package com.fasterxml.uuid.impl;
 
 import java.util.UUID;
 
+import com.fasterxml.uuid.UUIDTimer;
 import com.fasterxml.uuid.UUIDType;
 
 public class UUIDUtil
@@ -380,9 +381,9 @@ public class UUIDUtil
             case NAME_BASED_MD5:
                 return 0L;
             case TIME_BASED:
-                return _getTimestampFromUuidV1(uuid);
+                return UUIDTimer.timestampToEpoch(getTimestampFromUuidV1(uuid));
             case TIME_BASED_REORDERED:
-                return _getTimestampFromUuidV6(uuid);
+                return UUIDTimer.timestampToEpoch(getTimestampFromUuidV6(uuid));
             case TIME_BASED_EPOCH:
                 return _getTimestampFromUuidV7(uuid);
             default:
@@ -390,7 +391,13 @@ public class UUIDUtil
         }
     }
 
-    private static long _getTimestampFromUuidV1(UUID uuid) {
+    /**
+     * Get timestamp, used to create the UUID v1
+     *
+     * @param uuid uuid, to extract timestamp from
+     * @return timestamp, used to create uuid
+     */
+    static long getTimestampFromUuidV1(UUID uuid) {
         long mostSignificantBits = uuid.getMostSignificantBits();
         mostSignificantBits = mostSignificantBits & 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1110_1111_1111_1111L;
         long low = mostSignificantBits >>> 32;
@@ -400,7 +407,13 @@ public class UUIDUtil
         return highOfHigher << 48 | lowOfHigher << 32 | low;
     }
 
-    private static long _getTimestampFromUuidV6(UUID uuid) {
+    /**
+     * Get timestamp, used to create the UUID v6
+     *
+     * @param uuid uuid, to extract timestamp from
+     * @return timestamp, used to create uuid
+     */
+    static long getTimestampFromUuidV6(UUID uuid) {
         long mostSignificantBits = uuid.getMostSignificantBits();
         mostSignificantBits = mostSignificantBits & 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1001_1111_1111_1111L;
         long lowL = mostSignificantBits & 0xFFFL;

--- a/src/main/java/com/fasterxml/uuid/impl/UUIDUtil.java
+++ b/src/main/java/com/fasterxml/uuid/impl/UUIDUtil.java
@@ -361,7 +361,7 @@ public class UUIDUtil
      *
      * @param uuid uuid timestamp to extract from
      *
-     * @return timestamp in milliseconds (since Epoch), or 0 if type does not support timestamps
+     * @return Unix timestamp in milliseconds (since Epoch), or 0 if type does not support timestamps
      *
      * @since 5.0
      */
@@ -381,23 +381,25 @@ public class UUIDUtil
             case NAME_BASED_MD5:
                 return 0L;
             case TIME_BASED:
-                return UUIDTimer.timestampToEpoch(getTimestampFromUuidV1(uuid));
+                return UUIDTimer.timestampToEpoch(_getRawTimestampFromUuidV1(uuid));
             case TIME_BASED_REORDERED:
-                return UUIDTimer.timestampToEpoch(getTimestampFromUuidV6(uuid));
+                return UUIDTimer.timestampToEpoch(_getRawTimestampFromUuidV6(uuid));
             case TIME_BASED_EPOCH:
-                return _getTimestampFromUuidV7(uuid);
+                return _getRawTimestampFromUuidV7(uuid);
             default:
                 throw new IllegalArgumentException("Invalid `UUID`: unexpected type " + type);
         }
     }
 
     /**
-     * Get timestamp, used to create the UUID v1
+     * Get raw timestamp, used to create the UUID v1
+     *<p>
+     * NOTE: no verification is done to ensure UUID given is of version 1.
      *
      * @param uuid uuid, to extract timestamp from
-     * @return timestamp, used to create uuid
+     * @return timestamp, used to create uuid v1
      */
-    static long getTimestampFromUuidV1(UUID uuid) {
+    static long _getRawTimestampFromUuidV1(UUID uuid) {
         long mostSignificantBits = uuid.getMostSignificantBits();
         mostSignificantBits = mostSignificantBits & 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1110_1111_1111_1111L;
         long low = mostSignificantBits >>> 32;
@@ -408,12 +410,14 @@ public class UUIDUtil
     }
 
     /**
-     * Get timestamp, used to create the UUID v6
+     * Get raw timestamp, used to create the UUID v6.
+     *<p>
+     * NOTE: no verification is done to ensure UUID given is of version 6.
      *
      * @param uuid uuid, to extract timestamp from
-     * @return timestamp, used to create uuid
+     * @return timestamp, used to create uuid v6
      */
-    static long getTimestampFromUuidV6(UUID uuid) {
+    static long _getRawTimestampFromUuidV6(UUID uuid) {
         long mostSignificantBits = uuid.getMostSignificantBits();
         mostSignificantBits = mostSignificantBits & 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1001_1111_1111_1111L;
         long lowL = mostSignificantBits & 0xFFFL;
@@ -423,7 +427,7 @@ public class UUIDUtil
         return high >>> 4 | lowH << 12 | lowL;
     }
 
-    private static long _getTimestampFromUuidV7(UUID uuid) {
+    static long _getRawTimestampFromUuidV7(UUID uuid) {
         long mostSignificantBits = uuid.getMostSignificantBits();
         mostSignificantBits = mostSignificantBits & 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1001_1111_1111_1111L;
         return mostSignificantBits >>> 16;

--- a/src/test/java/com/fasterxml/uuid/impl/UUIDUtilTest.java
+++ b/src/test/java/com/fasterxml/uuid/impl/UUIDUtilTest.java
@@ -4,6 +4,7 @@ import java.util.Random;
 import java.util.UUID;
 
 import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.NoArgGenerator;
 import junit.framework.TestCase;
 
 /**
@@ -37,9 +38,17 @@ public class UUIDUtilTest extends TestCase
         for (int i = 0; i < TEST_REPS; i++) {
             long rawTimestamp = rnd.nextLong() >>> 4;
             UUID uuid = generator.construct(rawTimestamp);
-            assertEquals(rawTimestamp, UUIDUtil.extractTimestamp(uuid));
+            assertEquals(rawTimestamp, UUIDUtil.getTimestampFromUuidV1(uuid));
         }
     }
+
+    public void testExtractTimestampUUIDTimeBasedCurrentTimemillis() {
+        TimeBasedGenerator generator = Generators.timeBasedGenerator();
+        long time = System.currentTimeMillis();
+        UUID uuid2 = generator.generate();
+        assertEquals(time, UUIDUtil.extractTimestamp(uuid2));
+    }
+
 
     public void testExtractTimestampUUIDTimeBasedReordered() {
         TimeBasedReorderedGenerator generator = Generators.timeBasedReorderedGenerator();
@@ -47,8 +56,15 @@ public class UUIDUtilTest extends TestCase
         for (int i = 0; i < TEST_REPS; i++) {
             long rawTimestamp = rnd.nextLong() >>> 4;
             UUID uuid = generator.construct(rawTimestamp);
-            assertEquals(rawTimestamp, UUIDUtil.extractTimestamp(uuid));
+            assertEquals(rawTimestamp, UUIDUtil.getTimestampFromUuidV6(uuid));
         }
+    }
+
+    public void testExtractTimestampUUIDTimeBasedReorderedCurrentTimeMillis() {
+        NoArgGenerator generator = Generators.timeBasedReorderedGenerator();
+        long time = System.currentTimeMillis();
+        UUID uuid = generator.generate();
+        assertEquals(time, UUIDUtil.extractTimestamp(uuid));
     }
 
     public void testExtractTimestampUUIDEpochBased() {
@@ -60,6 +76,14 @@ public class UUIDUtilTest extends TestCase
             assertEquals(rawTimestamp, UUIDUtil.extractTimestamp(uuid));
         }
     }
+
+    public void testExtractTimestampUUIDEpochBasedCurrentTimeMillis() {
+        NoArgGenerator generator = Generators.timeBasedEpochGenerator();
+        long time = System.currentTimeMillis();
+        UUID uuid = generator.generate();
+        assertEquals(time, UUIDUtil.extractTimestamp(uuid));
+    }
+
 
     public void testExtractTimestampUUIDEpochRandomBased() {
         TimeBasedEpochRandomGenerator generator = Generators.timeBasedEpochRandomGenerator();

--- a/src/test/java/com/fasterxml/uuid/impl/UUIDUtilTest.java
+++ b/src/test/java/com/fasterxml/uuid/impl/UUIDUtilTest.java
@@ -38,7 +38,7 @@ public class UUIDUtilTest extends TestCase
         for (int i = 0; i < TEST_REPS; i++) {
             long rawTimestamp = rnd.nextLong() >>> 4;
             UUID uuid = generator.construct(rawTimestamp);
-            assertEquals(rawTimestamp, UUIDUtil.getTimestampFromUuidV1(uuid));
+            assertEquals(rawTimestamp, UUIDUtil._getRawTimestampFromUuidV1(uuid));
         }
     }
 
@@ -56,7 +56,7 @@ public class UUIDUtilTest extends TestCase
         for (int i = 0; i < TEST_REPS; i++) {
             long rawTimestamp = rnd.nextLong() >>> 4;
             UUID uuid = generator.construct(rawTimestamp);
-            assertEquals(rawTimestamp, UUIDUtil.getTimestampFromUuidV6(uuid));
+            assertEquals(rawTimestamp, UUIDUtil._getRawTimestampFromUuidV6(uuid));
         }
     }
 


### PR DESCRIPTION
Added lost conversion to unix epoch for v1 & v6, to fix #105.